### PR TITLE
Add platformio configuration.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,7 @@ src_dir = .
 
 [env:default]
 platform = atmelavr
+build_flags = -DDISABLE_JOIN -DDISABLE_PING -DDISABLE_BEACONS
 board = feather32u4
 framework = arduino
 monitor_speed = 115200

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,25 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[env:default]
+platform = atmelavr
+board = feather32u4
+framework = arduino
+monitor_speed = 115200
+
+lib_deps =
+    LMIC-arduino
+    Adafruit Unified Sensor
+    Adafruit BME280 Library
+    DHT sensor library
+


### PR DESCRIPTION
Dit voegt een zogenaamde platformio configuratie toe.

Hiermee kan je de software compileren zonder dat je de Arduino IDE nodig hebt. De benodigde libraries worden automatisch gedownload. De libraries.zip file is dan in principe niet meer nodig.

Dit maakt het in principe ook mogelijk om de software automatisch te laten bouwen bij een service zoals travis-ci.org, dan wordt bij elke code-verandering die je naar github pusht direct gecontroleerd of de code nog correct compileert. 